### PR TITLE
Fix schema type of vidmethod lookup to look for URI schema type. 

### DIFF
--- a/api/toip-tswg-trustregistryprotocol-v2.yaml
+++ b/api/toip-tswg-trustregistryprotocol-v2.yaml
@@ -314,7 +314,7 @@ paths:
           name: egfURI
           required: true
           schema:
-            $ref: '#/components/schemas/VIDMethodListType'
+            $ref: '#/components/schemas/URI'
           description: >
             Provides a list of DID-methods that are supported by this trust
             registry. MAY include Maximum Assurance Level 


### PR DESCRIPTION
fix schema type for lookup of VID Method. Parameter asks for egfURI and schema request is VIDMethodListType. This fixes this issue. 