### PR TITLE
fix URI schema for VID Method Lookups

### DIFF
--- a/api/toip-tswg-trustregistryprotocol-v2.yaml
+++ b/api/toip-tswg-trustregistryprotocol-v2.yaml
@@ -314,7 +314,7 @@ paths:
           name: egfURI
           required: true
           schema:
-            $ref: '#/components/schemas/VIDMethodListType'
+            $ref: '#/components/schemas/Uri'
           description: >
             Provides a list of DID-methods that are supported by this trust
             registry. MAY include Maximum Assurance Level 


### PR DESCRIPTION
re-pull of #65 to avoid branch protection rules with a fix of changing VIDMethod Lookup to a URI.