### PR TITLE
typo: examples

### DIFF
--- a/api/toip-tswg-trustregistryprotocol-v2.yaml
+++ b/api/toip-tswg-trustregistryprotocol-v2.yaml
@@ -596,7 +596,7 @@ components:
         governanceFrameworkVID:
           type: string
           format: uri
-          exampls: 
+          examples: 
             - "did:example:456"
         primaryTrustRegistryVID:
           type: string


### PR DESCRIPTION
fix spelling of examples.